### PR TITLE
Fix inconsistent network buffer values

### DIFF
--- a/app/src/main/java/com/kybers/play/data/preferences/PreferenceManager.kt
+++ b/app/src/main/java/com/kybers/play/data/preferences/PreferenceManager.kt
@@ -179,8 +179,12 @@ class PreferenceManager(context: Context) {
         // Apply network buffer setting
         val networkBuffer = getNetworkBuffer()
         val bufferValue = when (networkBuffer) {
-            "LOW" -> "1000"
+            // New standard values used across UI and dynamic recommendations
+            "SMALL" -> "1000"
             "MEDIUM" -> "3000"
+            "LARGE" -> "5000"
+            // Legacy values kept for backward compatibility
+            "LOW" -> "1000"
             "HIGH" -> "5000"
             "ULTRA" -> "8000"
             else -> "3000"


### PR DESCRIPTION
## Summary
- align `PreferenceManager`'s VLC options with UI network buffer values

## Testing
- `./gradlew test` *(fails: missing SDK packages and license agreements)*

------
https://chatgpt.com/codex/tasks/task_e_68962f58e71083249bedc9ae8e310127