### PR TITLE
Use MediaManager for dynamic VLC updates

### DIFF
--- a/app/src/main/java/com/kybers/play/ui/channels/ChannelsViewModel.kt
+++ b/app/src/main/java/com/kybers/play/ui/channels/ChannelsViewModel.kt
@@ -774,8 +774,7 @@ open class ChannelsViewModel(
                 val newMedia = Media(libVLC, media.uri).apply {
                     newOptions.forEach { addOption(it) }
                 }
-                mediaPlayer.media?.release()
-                mediaPlayer.media = newMedia
+                mediaManager.setMediaSafely(mediaPlayer, newMedia)
                 mediaPlayer.play()
                 mediaPlayer.time = currentPosition
             }

--- a/app/src/main/java/com/kybers/play/ui/movies/MovieDetailsViewModel.kt
+++ b/app/src/main/java/com/kybers/play/ui/movies/MovieDetailsViewModel.kt
@@ -653,8 +653,7 @@ class MovieDetailsViewModel(
                 val newMedia = Media(libVLC, media.uri).apply {
                     newOptions.forEach { addOption(it) }
                 }
-                mediaPlayer.media?.release()
-                mediaPlayer.media = newMedia
+                mediaManager.setMediaSafely(mediaPlayer, newMedia)
                 mediaPlayer.play()
                 mediaPlayer.time = currentPosition
             }

--- a/app/src/main/java/com/kybers/play/ui/series/SeriesDetailsViewModel.kt
+++ b/app/src/main/java/com/kybers/play/ui/series/SeriesDetailsViewModel.kt
@@ -700,8 +700,7 @@ class SeriesDetailsViewModel(
                 val newMedia = Media(libVLC, media.uri).apply {
                     newOptions.forEach { addOption(it) }
                 }
-                mediaPlayer.media?.release()
-                mediaPlayer.media = newMedia
+                mediaManager.setMediaSafely(mediaPlayer, newMedia)
                 mediaPlayer.play()
                 mediaPlayer.time = currentPosition
             }


### PR DESCRIPTION
## Summary
- Ensure updatePlayerSettings uses MediaManager to swap VLC media safely
- Prevent potential memory leaks when applying new VLC options during playback

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689641d72fe48324b28b8c52323d357e