### PR TITLE
Ensure VLC media objects are released explicitly

### DIFF
--- a/app/src/androidTest/java/com/kybers/play/player/MediaReleaseTest.kt
+++ b/app/src/androidTest/java/com/kybers/play/player/MediaReleaseTest.kt
@@ -1,0 +1,39 @@
+package com.kybers.play.player
+
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.videolan.libvlc.LibVLC
+import org.videolan.libvlc.Media
+import org.videolan.libvlc.MediaPlayer
+
+@RunWith(AndroidJUnit4::class)
+class MediaReleaseTest {
+
+    @Test
+    fun mediaIsReleasedWithoutNativeLeaks() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val libVLC = LibVLC(context)
+        val mediaPlayer = MediaPlayer(libVLC)
+        val mediaManager = MediaManager()
+
+        val media = Media(libVLC, Uri.parse("http://example.com"))
+        try {
+            mediaManager.setMediaSafely(mediaPlayer, media)
+        } finally {
+            mediaManager.stopAndReleaseMedia(mediaPlayer)
+            mediaPlayer.release()
+            libVLC.release()
+        }
+
+        // Allow time for log messages to be written
+        Thread.sleep(500)
+
+        val logProcess = Runtime.getRuntime().exec(arrayOf("logcat", "-d", "VLCObject"))
+        val logs = logProcess.inputStream.bufferedReader().use { it.readText() }
+        assertFalse("VLCObject leak detected", logs.contains("VLCObject"))
+    }
+}

--- a/app/src/main/java/com/kybers/play/player/PlayerManager.kt
+++ b/app/src/main/java/com/kybers/play/player/PlayerManager.kt
@@ -194,6 +194,7 @@ class PlayerManager(
                 true
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to play media", e)
+                mediaManager.releaseCurrentMedia(mediaPlayer!!)
                 false
             }
         } ?: run {
@@ -205,6 +206,7 @@ class PlayerManager(
                 Log.d(TAG, "Media playback started (no retry)")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to play media (no retry)", e)
+                mediaManager.releaseCurrentMedia(mediaPlayer!!)
                 onError?.invoke("Error al reproducir el contenido")
             }
         }


### PR DESCRIPTION
## Summary
- release current VLC media on playback errors in PlayerManager and view models
- guard dynamic media updates with cleanup logic
- add instrumentation test verifying no `VLCObject` leaks after releasing media

## Testing
- `./gradlew test` *(fails: SDK location/licences missing)*
- `./gradlew connectedDebugAndroidTest` *(fails: SDK licences not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_689648981f3483248c0f3448a052ddf5