### PR TITLE
Corrige referencias de IVLCVout en VLCPlayer

### DIFF
--- a/app/src/main/java/com/kybers/play/ui/player/VLCPlayer.kt
+++ b/app/src/main/java/com/kybers/play/ui/player/VLCPlayer.kt
@@ -11,8 +11,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
-import org.videolan.libvlc.IVLCVout
 import org.videolan.libvlc.MediaPlayer
+import org.videolan.libvlc.interfaces.IVLCVout
 import org.videolan.libvlc.util.VLCVideoLayout
 
 /**
@@ -26,7 +26,7 @@ fun VLCPlayer(mediaPlayer: MediaPlayer, modifier: Modifier = Modifier) {
     val vlcVout = mediaPlayer.vlcVout
     val videoLayout = remember { VLCVideoLayout(context) }
     val voutCallback = remember {
-        object : IVLCVout.Callback {
+        object : IVLCVout.Callback, IVLCVout.OnNewVideoLayoutListener {
             override fun onNewVideoLayout(
                 vlcVout: IVLCVout?,
                 width: Int,
@@ -49,13 +49,12 @@ fun VLCPlayer(mediaPlayer: MediaPlayer, modifier: Modifier = Modifier) {
         }
     }
 
-    DisposableEffect(vlcVout, videoLayout) {
-        vlcVout.setVideoView(videoLayout)
-        vlcVout.attachViews()
+    DisposableEffect(mediaPlayer, videoLayout) {
         vlcVout.addCallback(voutCallback)
+        mediaPlayer.attachViews(videoLayout, null, false, false)
         onDispose {
             vlcVout.removeCallback(voutCallback)
-            vlcVout.detachViews()
+            mediaPlayer.detachViews()
         }
     }
 


### PR DESCRIPTION
## Resumen
- Ajusta las importaciones de IVLCVout al paquete `interfaces`
- Usa `MediaPlayer.attachViews` para gestionar superficies y callbacks de vídeo

## Pruebas
- `./gradlew :app:compileDebugKotlin` *(falla: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896501cc0208324ab2c63567cab5806