### PR TITLE
Release media on retry failure

### DIFF
--- a/app/src/main/java/com/kybers/play/ui/channels/ChannelsViewModel.kt
+++ b/app/src/main/java/com/kybers/play/ui/channels/ChannelsViewModel.kt
@@ -273,12 +273,13 @@ open class ChannelsViewModel(
                 }
             },
             onRetryFailed = {
-                _uiState.update { 
+                mediaManager.stopAndReleaseMedia(mediaPlayer)
+                _uiState.update {
                     it.copy(
                         playerStatus = PlayerStatus.RETRY_FAILED,
                         retryAttempt = 0,
                         retryMessage = "Error de conexión. Verifica tu red e inténtalo de nuevo."
-                    ) 
+                    )
                 }
             }
         )

--- a/app/src/main/java/com/kybers/play/ui/movies/MovieDetailsViewModel.kt
+++ b/app/src/main/java/com/kybers/play/ui/movies/MovieDetailsViewModel.kt
@@ -425,12 +425,13 @@ class MovieDetailsViewModel(
                 }
             },
             onRetryFailed = {
-                _uiState.update { 
+                mediaManager.stopAndReleaseMedia(mediaPlayer)
+                _uiState.update {
                     it.copy(
                         playerStatus = PlayerStatus.RETRY_FAILED,
                         retryAttempt = 0,
                         retryMessage = "Error de conexión. Verifica tu red e inténtalo de nuevo."
-                    ) 
+                    )
                 }
             }
         )

--- a/app/src/main/java/com/kybers/play/ui/series/SeriesDetailsViewModel.kt
+++ b/app/src/main/java/com/kybers/play/ui/series/SeriesDetailsViewModel.kt
@@ -384,12 +384,13 @@ class SeriesDetailsViewModel(
                 }
             },
             onRetryFailed = {
-                _uiState.update { 
+                mediaManager.stopAndReleaseMedia(mediaPlayer)
+                _uiState.update {
                     it.copy(
                         playerStatus = PlayerStatus.RETRY_FAILED,
                         retryAttempt = 0,
                         retryMessage = "Error de conexión. Verifica tu red e inténtalo de nuevo."
-                    ) 
+                    )
                 }
             }
         )


### PR DESCRIPTION
## Summary
- release media player resources when all retries fail for channels, movies and series

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `adb logcat -d` *(fails: waiting for device)*

------
https://chatgpt.com/codex/tasks/task_e_6896558e20a08324ac04464ca82e3417