### PR TITLE
feat: move user loading to MainViewModel

### DIFF
--- a/app/src/main/java/com/kybers/play/ui/ViewModelFactory.kt
+++ b/app/src/main/java/com/kybers/play/ui/ViewModelFactory.kt
@@ -23,6 +23,8 @@ import com.kybers.play.ui.series.SeriesDetailsViewModel
 import com.kybers.play.ui.series.SeriesViewModel
 import com.kybers.play.ui.settings.SettingsViewModel
 import com.kybers.play.ui.sync.SyncViewModel
+import com.kybers.play.ui.main.MainViewModel
+import com.kybers.play.AppContainer
 
 class LoginViewModelFactory(private val userRepository: UserRepository) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -166,6 +168,19 @@ class SettingsViewModelFactory(
         if (modelClass.isAssignableFrom(SettingsViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
             return SettingsViewModel(context, liveRepository, vodRepository, preferenceManager, syncManager, currentUser, parentalControlManager, themeManager) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}
+
+class MainViewModelFactory(
+    private val appContainer: AppContainer,
+    private val userId: Int
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return MainViewModel(appContainer, userId) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
     }

--- a/app/src/main/java/com/kybers/play/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/kybers/play/ui/main/MainViewModel.kt
@@ -1,0 +1,49 @@
+package com.kybers.play.ui.main
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kybers.play.AppContainer
+import com.kybers.play.data.local.model.User
+import com.kybers.play.data.repository.LiveRepository
+import com.kybers.play.data.repository.VodRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+// Representa el estado de la navegación principal
+// Mantiene al usuario y repositorios cargados
+
+data class MainUiState(
+    val isLoading: Boolean = true,
+    val user: User? = null,
+    val vodRepository: VodRepository? = null,
+    val liveRepository: LiveRepository? = null
+)
+
+class MainViewModel(
+    private val appContainer: AppContainer,
+    private val userId: Int
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(MainUiState())
+    val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
+
+    init {
+        loadUser()
+    }
+
+    private fun loadUser() {
+        viewModelScope.launch {
+            val user = appContainer.userRepository.getUserById(userId)
+            val vodRepo = user?.let { appContainer.createVodRepository(it.url) }
+            val liveRepo = user?.let { appContainer.createLiveRepository(it.url) }
+            _uiState.value = MainUiState(
+                isLoading = false,
+                user = user,
+                vodRepository = vodRepo,
+                liveRepository = liveRepo
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract user lookup and repository creation into `MainViewModel`
- simplify `AppNavigation` to observe `MainViewModel` `uiState`
- expose `MainViewModelFactory` for dependency injection

## Testing
- `./gradlew :app:assembleDebug :app:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896dcb42d5c8324b76707912f804268