### PR TITLE
Handle null currentDestination and user in AppNavigation

### DIFF
--- a/app/src/main/java/com/kybers/play/ui/main/AppNavigation.kt
+++ b/app/src/main/java/com/kybers/play/ui/main/AppNavigation.kt
@@ -154,8 +154,9 @@ private fun MainScreenWithBottomNav(
                     viewModel = viewModel,
                     onNavigateUp = { navController.popBackStack() },
                     onNavigateToMovie = { newMovieId ->
+                        val destinationId = navController.currentDestination?.id ?: return@onNavigateToMovie
                         navController.navigate(Screen.MovieDetails.createRoute(newMovieId)) {
-                            popUpTo(navController.currentDestination!!.id) { inclusive = true }
+                            popUpTo(destinationId) { inclusive = true }
                         }
                     }
                 )
@@ -171,8 +172,9 @@ private fun MainScreenWithBottomNav(
                     viewModel = viewModel,
                     onNavigateUp = { navController.popBackStack() },
                     onNavigateToSeries = { newSeriesId ->
+                        val destinationId = navController.currentDestination?.id ?: return@onNavigateToSeries
                         navController.navigate(Screen.SeriesDetails.createRoute(newSeriesId)) {
-                            popUpTo(navController.currentDestination!!.id) { inclusive = true }
+                            popUpTo(destinationId) { inclusive = true }
                         }
                     }
                 )
@@ -252,7 +254,7 @@ fun AppNavHost(
                     }
                 }
                 uiState.user != null -> {
-                    val user = uiState.user!!
+                    val user = requireNotNull(uiState.user)
                     val vodRepository = uiState.vodRepository!!
                     val liveRepository = uiState.liveRepository!!
 

--- a/app/src/main/java/com/kybers/play/ui/main/AppNavigation.kt
+++ b/app/src/main/java/com/kybers/play/ui/main/AppNavigation.kt
@@ -154,9 +154,10 @@ private fun MainScreenWithBottomNav(
                     viewModel = viewModel,
                     onNavigateUp = { navController.popBackStack() },
                     onNavigateToMovie = { newMovieId ->
-                        val destinationId = navController.currentDestination?.id ?: return@onNavigateToMovie
-                        navController.navigate(Screen.MovieDetails.createRoute(newMovieId)) {
-                            popUpTo(destinationId) { inclusive = true }
+                        navController.currentDestination?.id?.let { destinationId ->
+                            navController.navigate(Screen.MovieDetails.createRoute(newMovieId)) {
+                                popUpTo(destinationId) { inclusive = true }
+                            }
                         }
                     }
                 )
@@ -172,9 +173,10 @@ private fun MainScreenWithBottomNav(
                     viewModel = viewModel,
                     onNavigateUp = { navController.popBackStack() },
                     onNavigateToSeries = { newSeriesId ->
-                        val destinationId = navController.currentDestination?.id ?: return@onNavigateToSeries
-                        navController.navigate(Screen.SeriesDetails.createRoute(newSeriesId)) {
-                            popUpTo(destinationId) { inclusive = true }
+                        navController.currentDestination?.id?.let { destinationId ->
+                            navController.navigate(Screen.SeriesDetails.createRoute(newSeriesId)) {
+                                popUpTo(destinationId) { inclusive = true }
+                            }
                         }
                     }
                 )


### PR DESCRIPTION
## Summary
- Avoid NPE by checking currentDestination before popping the back stack
- Replace unsafe `user!!` with `requireNotNull`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e7fb28b08324b0b0fa890ebf88f9