### PR TITLE
refactor: avoid non-null assertion in SeriesDetailsScreen

### DIFF
--- a/app/src/main/java/com/kybers/play/ui/series/SeriesDetailsScreen.kt
+++ b/app/src/main/java/com/kybers/play/ui/series/SeriesDetailsScreen.kt
@@ -156,11 +156,12 @@ fun SeriesDetailsScreen(
                 .fillMaxSize()
                 .padding(if (!uiState.isFullScreen && !uiState.isInPipMode) paddingValues else PaddingValues(0.dp))
         ) {
+            val errorMessage = uiState.error
             if (uiState.isLoading) {
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
-            } else if (uiState.error != null) {
+            } else if (errorMessage != null) {
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text(text = uiState.error, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(16.dp))
+                    Text(text = errorMessage, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(16.dp))
                 }
             } else {
                 SeriesPlayerSection(viewModel = viewModel, audioManager = audioManager, onNavigateUp = onNavigateUp)

--- a/app/src/main/java/com/kybers/play/ui/series/SeriesDetailsScreen.kt
+++ b/app/src/main/java/com/kybers/play/ui/series/SeriesDetailsScreen.kt
@@ -160,7 +160,7 @@ fun SeriesDetailsScreen(
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
             } else if (uiState.error != null) {
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text(text = uiState.error!!, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(16.dp))
+                    Text(text = uiState.error, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(16.dp))
                 }
             } else {
                 SeriesPlayerSection(viewModel = viewModel, audioManager = audioManager, onNavigateUp = onNavigateUp)


### PR DESCRIPTION
## Summary
- remove unnecessary non-null assertion on error message in SeriesDetailsScreen

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*
- `./gradlew :app:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897bdef79448324be43adab4a64b2d4