### PR TITLE
Fix continue watching for series

### DIFF
--- a/app/src/main/java/com/kybers/play/ui/series/SeriesDetailsScreen.kt
+++ b/app/src/main/java/com/kybers/play/ui/series/SeriesDetailsScreen.kt
@@ -610,6 +610,7 @@ private fun SeriesActionButtonsSection(
     modifier: Modifier = Modifier
 ) {
     val continueEpisode = viewModel.getContinueWatchingEpisode()
+    val lastWatchedEpisode = viewModel.getLastWatchedEpisode()
     val allEpisodes = uiState.episodesBySeason.values.flatten()
     val firstEpisode = allEpisodes.minWithOrNull(compareBy<Episode>({ it.season }, { it.episodeNum }))
     val hasProgress = continueEpisode != null && continueEpisode != firstEpisode
@@ -687,6 +688,7 @@ fun SeriesCarousel(title: String, series: List<Series>, onSeriesClick: (Int) -> 
             LazyRow(
                 contentPadding = PaddingValues(horizontal = 16.dp),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
                 items(series, key = { it.seriesId }) { seriesItem ->
                     EnhancedSeriesPosterItem(
                         series = seriesItem,

--- a/app/src/main/java/com/kybers/play/ui/series/SeriesDetailsScreen.kt
+++ b/app/src/main/java/com/kybers/play/ui/series/SeriesDetailsScreen.kt
@@ -609,8 +609,10 @@ private fun SeriesActionButtonsSection(
     viewModel: SeriesDetailsViewModel,
     modifier: Modifier = Modifier
 ) {
-    val lastWatchedEpisode = viewModel.getLastWatchedEpisode()
-    val hasProgress = lastWatchedEpisode != null
+    val continueEpisode = viewModel.getContinueWatchingEpisode()
+    val allEpisodes = uiState.episodesBySeason.values.flatten()
+    val firstEpisode = allEpisodes.minWithOrNull(compareBy<Episode>({ it.season }, { it.episodeNum }))
+    val hasProgress = continueEpisode != null && continueEpisode != firstEpisode
 
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -624,7 +626,7 @@ private fun SeriesActionButtonsSection(
             modifier = Modifier.fillMaxWidth()
         ) {
             Icon(
-                imageVector = if (hasProgress) Icons.Default.PlayArrow else Icons.Default.PlayArrow,
+                imageVector = Icons.Default.PlayArrow,
                 contentDescription = null,
                 modifier = Modifier.size(18.dp)
             )
@@ -637,16 +639,13 @@ private fun SeriesActionButtonsSection(
             )
         }
 
-        // Información del último episodio visto
+        // Botón para reiniciar la serie
         if (hasProgress) {
             OutlinedButton(
-                onClick = { 
-                    // Start from beginning of the series
-                    val firstEpisode = uiState.episodesBySeason.values.flatten()
-                        .minByOrNull { it.episodeNum }
+                onClick = {
                     firstEpisode?.let { viewModel.playEpisode(it) }
                 },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 Icon(
                     imageVector = Icons.Default.Replay,
@@ -688,7 +687,6 @@ fun SeriesCarousel(title: String, series: List<Series>, onSeriesClick: (Int) -> 
             LazyRow(
                 contentPadding = PaddingValues(horizontal = 16.dp),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
                 items(series, key = { it.seriesId }) { seriesItem ->
                     EnhancedSeriesPosterItem(
                         series = seriesItem,


### PR DESCRIPTION
## Summary
- Save series playback progress to surface shows in "continue watching"
- Improve episode selection for continue watching and allow restart from beginning

## Testing
- `./gradlew :app:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897c6eb3c348324ab9829dc6bea77ec